### PR TITLE
Add Fhenix Confidential Intent integration issue and refine dashboard copy

### DIFF
--- a/apps/dashboard/src/components/CreateIntentView.tsx
+++ b/apps/dashboard/src/components/CreateIntentView.tsx
@@ -187,7 +187,12 @@ export const CreateIntentView: FC<CreateIntentViewProps> = ({ onIntentSubmitted 
 								</div>
 								<div>
 									<p className="text-sm font-bold uppercase tracking-tight" style={{ color: "var(--fg-primary)" }}>Fhenix Confidential Intent</p>
-									<p className="text-[10px] font-semibold tracking-wide" style={{ color: "var(--fg-muted)" }}>Encrypt constraints for agent-only visibility (CCM).</p>
+									<p className="text-[10px] font-semibold tracking-wide" style={{ color: "var(--fg-muted)" }}>
+										Deep-critical, well-structured CCM constraints.
+									</p>
+									<p className="text-[10px] font-semibold tracking-wide" style={{ color: "var(--fg-muted)" }}>
+										Encrypted for agent-only visibility (CCM).
+									</p>
 								</div>
 							</div>
 							<button
@@ -221,7 +226,7 @@ export const CreateIntentView: FC<CreateIntentViewProps> = ({ onIntentSubmitted 
 					<div className="space-y-5">
 						{[
 							{ step: '1', title: 'Solver Selection', desc: 'Yellow Fusion+ Bonded' },
-							{ step: '2', title: 'Confidentiality', desc: 'Fhenix Encrypted CCM' },
+							{ step: '2', title: 'Confidentiality', desc: 'Fhenix Encrypted CCM (agent-only)' },
 							{ step: '3', title: 'Cross-chain Hop', desc: 'LI.FI Stargate Abstraction' },
 							{ step: '4', title: 'Atomic Settlement', desc: 'Uniswap v4 JACK Hook' }
 						].map((item) => (

--- a/docs/issues/issue-fhenix-confidential-intent-integration.md
+++ b/docs/issues/issue-fhenix-confidential-intent-integration.md
@@ -1,0 +1,57 @@
+# Issue: Fhenix Confidential Intent (CCM) Integration for JACK
+
+## Status
+- **State:** Pending
+
+## Summary
+Define and implement the integration plan for **Fhenix Confidential Intent** so that **CCM (Confidential Constraint Mechanism)** policies are encrypted and visible only to authorized agents, while still being enforceable on-chain. This issue tracks the deep-critical requirements, architecture, and delivery plan for integrating Fhenix into JACK’s intent flow.
+
+## Background
+JACK’s intent pipeline includes constraint enforcement and settlement hooks. To preserve strategic privacy, CCM constraints should be encrypted and executed without exposing constraint parameters on-chain. Fhenix provides fully homomorphic encryption (FHE) primitives that can enable private policy enforcement while retaining verifiability.
+
+## Goals
+- Enable **agent-only visibility** for CCM constraints (policy inputs/parameters).
+- Ensure **on-chain enforceability** of confidential constraints without revealing the plaintext.
+- Define a **secure key management and access model** for authorized agents and solvers.
+- Establish **clear integration milestones** across SDK, contracts, and UI.
+
+## Scope
+- **SDK**: intent creation, CCM payload encryption, typed data signing updates.
+- **Contracts**: validation hooks, ciphertext handling, and fail-closed enforcement.
+- **Solver/Agent**: authorized decryption workflow, policy evaluation, and execution proofs.
+- **UI/UX**: user-facing copy, privacy toggles, and status indicators for confidential intents.
+- **Infra**: key management, enclave or MPC boundary (if required), and auditing.
+
+## Proposed Integration (High-Level)
+1. **CCM Payload Definition**
+   - Define a CCM schema (constraints, thresholds, slippage caps, time locks).
+   - Specify what is encrypted vs. public metadata.
+2. **Encryption + Signing Flow**
+   - Encrypt CCM payload using Fhenix-compatible keys.
+   - Extend typed data to include a CCM ciphertext hash/commitment.
+3. **On-Chain Enforcement**
+   - Update hooks to validate ciphertext commitments and enforce fail-closed behavior.
+   - Define on-chain verification inputs and event emissions for observability.
+4. **Solver/Agent Decryption**
+   - Authorized agents decrypt CCM payloads and run policy evaluation.
+   - Maintain audit trail and proof of constraint adherence.
+5. **UI and Status**
+   - Indicate “Confidential Intent” and “CCM encrypted for agent-only visibility.”
+   - Provide deterministic status updates for encryption, broadcast, and settlement.
+
+## Risks & Constraints
+- **Key management** and access control for CCM decryption.
+- **Latency** introduced by encryption/decryption and verification.
+- **Chain compatibility** with Fhenix primitives and existing hooks.
+- **Security guarantees** for fail-closed enforcement under solver misbehavior.
+
+## Acceptance Criteria
+- Documented CCM schema with encrypted/public fields.
+- SDK can encrypt CCM payloads and submit confidential intents.
+- On-chain hooks validate CCM commitments and enforce fail-closed execution.
+- Authorized agents can decrypt, evaluate, and log constraint compliance.
+- UI clearly marks intents as “Fhenix Confidential Intent (CCM).”
+
+## References
+- Fhenix documentation (TBD: add exact URLs).
+- JACK confidential intent UI copy requirements.


### PR DESCRIPTION
### Motivation
- Provide a tracked, structured engineering/design issue that captures the goals, scope, acceptance criteria, and risks for integrating Fhenix Confidential Intent (CCM) into JACK.
- Improve dashboard UI copy to better communicate that CCM constraints are deep-critical, well-structured, and encrypted for agent-only visibility.

### Description
- Added a new issue document at `docs/issues/issue-fhenix-confidential-intent-integration.md` outlining integration goals, scope, proposed flow (CCM payload, encryption/signing, on-chain enforcement, solver decryption, UI), risks, and acceptance criteria.
- Updated `apps/dashboard/src/components/CreateIntentView.tsx` to expand the Fhenix Confidential Intent copy to emphasize "deep-critical, well-structured CCM constraints" and to add an explicit line stating the constraints are "Encrypted for agent-only visibility (CCM)."
- Updated the Route Topology confidentiality label to read `Fhenix Encrypted CCM (agent-only)` to make agent-only visibility explicit in the topology UI.

### Testing
- Ran pre-commit hooks which executed `secretlint`, and the hook passed (no secrets found). 
- No application build or UI integration tests were executed in this change; the documentation and copy changes require a dashboard build to validate visual appearance and runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986fa694740833298b138a26414db2a)