### PR TITLE
Add production-ready JACKSettlementAdapter (swap execution, sig checks, ACL) and tests

### DIFF
--- a/contracts/JACKSettlementAdapter.sol
+++ b/contracts/JACKSettlementAdapter.sol
@@ -1,51 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {JACKPolicyHook} from "./src/JACKPolicyHook.sol";
-
-/**
- * @title JACKSettlementAdapter
- * @notice Settles Solved Intents by interacting with the JACKPolicyHook and Uniswap v4.
- * @dev MVP stub – swap execution is mocked; policy integration is live.
- */
-contract JACKSettlementAdapter {
-    JACKPolicyHook public immutable policyHook;
-    error PolicyRejected(bytes32 intentId, bytes32 reason);
-
-    struct Intent {
-        bytes32 id;
-        address user;
-        address tokenIn;
-        address tokenOut;
-        uint256 amountIn;
-        uint256 minAmountOut;
-        uint256 deadline;
-        bytes signature;
-    }
-
-    event IntentSettled(bytes32 indexed intentId, address indexed solver);
-
-    constructor(address _policyHook) {
-        policyHook = JACKPolicyHook(_policyHook);
-    }
-
-    /**
-     * @notice Settles an intent by validating policy and executing the swap.
-     * @dev In a real V4 implementation, this would call the PoolManager.
-     */
-    function settleIntent(
-        Intent calldata intent,
-        bytes32, /* poolId – unused in MVP stub */
-        bytes calldata /* solverSignature – unused in MVP stub */
-    ) external {
-        // 1. Verify Intent Signature (Mock for MVP)
-        // 2. Validate an already-registered policy in the hook.
-        (bool allowed, bytes32 reason) = policyHook.checkPolicy(intent.id, intent.minAmountOut);
-        if (!allowed) revert PolicyRejected(intent.id, reason);
-
-        // 3. Execute Swap (Mock for MVP - would call PoolManager.unlock and perform swap)
-        // For the demo, we emit a success event.
-
-        emit IntentSettled(intent.id, msg.sender);
-    }
-}
+// Canonical source is contracts/src/JACKSettlementAdapter.sol.
+// Re-exported here for backward compatibility with existing imports.
+import {JACKSettlementAdapter} from "./src/JACKSettlementAdapter.sol";

--- a/contracts/src/JACKSettlementAdapter.sol
+++ b/contracts/src/JACKSettlementAdapter.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {EIP712} from "openzeppelin-contracts/utils/cryptography/EIP712.sol";
+import {SignatureChecker} from "openzeppelin-contracts/utils/cryptography/SignatureChecker.sol";
+import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {BalanceDelta, BalanceDeltaLibrary} from "v4-core/types/BalanceDelta.sol";
+import {Currency, CurrencyLibrary} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {SwapParams} from "v4-core/types/PoolOperation.sol";
+import {JACKPolicyHook} from "./JACKPolicyHook.sol";
+
+interface IUnlockCallback {
+    function unlockCallback(bytes calldata data) external returns (bytes memory);
+}
+
+/**
+ * @title JACKSettlementAdapter
+ * @notice Settles Solved Intents by interacting with the JACKPolicyHook and Uniswap v4.
+ */
+contract JACKSettlementAdapter is EIP712, ReentrancyGuard, IUnlockCallback {
+    using BalanceDeltaLibrary for BalanceDelta;
+    using CurrencyLibrary for Currency;
+
+    error PolicyRejected(bytes32 intentId, bytes32 reason);
+    error InvalidSignature();
+    error UnauthorizedSolver(address solver);
+    error UnauthorizedPoolManager(address caller);
+    error IntentExpired(uint256 deadline, uint256 currentTimestamp);
+    error QuotedAmountOutTooLow(uint256 quotedAmountOut, uint256 minAmountOut);
+    error Unauthorized();
+
+    event IntentSettled(bytes32 indexed intentId, address indexed solver);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event SolverAuthorizationUpdated(address indexed solver, bool authorized);
+
+    struct Intent {
+        bytes32 id;
+        address user;
+        address tokenIn;
+        address tokenOut;
+        uint256 amountIn;
+        uint256 minAmountOut;
+        uint256 deadline;
+        bytes signature;
+    }
+
+    struct SettlementData {
+        Intent intent;
+        PoolKey poolKey;
+        SwapParams swapParams;
+        uint256 quotedAmountOut;
+        address solver;
+    }
+
+    bytes32 private constant INTENT_TYPEHASH = keccak256(
+        "Intent(bytes32 id,address user,address tokenIn,address tokenOut,uint256 amountIn,uint256 minAmountOut,uint256 deadline)"
+    );
+
+    JACKPolicyHook public immutable policyHook;
+    IPoolManager public immutable poolManager;
+    address public owner;
+    mapping(address => bool) public authorizedSolvers;
+
+    constructor(address _policyHook) EIP712("JACKSettlementAdapter", "1") {
+        policyHook = JACKPolicyHook(_policyHook);
+        poolManager = policyHook.poolManager();
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert Unauthorized();
+        _;
+    }
+
+    modifier onlySolver() {
+        if (msg.sender != owner && !authorizedSolvers[msg.sender]) {
+            revert UnauthorizedSolver(msg.sender);
+        }
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert Unauthorized();
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+
+    function setAuthorizedSolver(address solver, bool authorized) external onlyOwner {
+        authorizedSolvers[solver] = authorized;
+        emit SolverAuthorizationUpdated(solver, authorized);
+    }
+
+    function hashIntent(Intent calldata intent) public view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    INTENT_TYPEHASH,
+                    intent.id,
+                    intent.user,
+                    intent.tokenIn,
+                    intent.tokenOut,
+                    intent.amountIn,
+                    intent.minAmountOut,
+                    intent.deadline
+                )
+            )
+        );
+    }
+
+    /**
+     * @notice Settles an intent by validating policy and executing the swap.
+     */
+    function settleIntent(
+        Intent calldata intent,
+        PoolKey calldata poolKey,
+        SwapParams calldata swapParams,
+        uint256 quotedAmountOut
+    ) external nonReentrant onlySolver {
+        if (intent.deadline < block.timestamp) {
+            revert IntentExpired(intent.deadline, block.timestamp);
+        }
+
+        if (quotedAmountOut < intent.minAmountOut) {
+            revert QuotedAmountOutTooLow(quotedAmountOut, intent.minAmountOut);
+        }
+
+        if (!SignatureChecker.isValidSignatureNow(intent.user, hashIntent(intent), intent.signature)) {
+            revert InvalidSignature();
+        }
+
+        (bool allowed, bytes32 reason) = policyHook.checkPolicy(intent.id, quotedAmountOut);
+        if (!allowed) revert PolicyRejected(intent.id, reason);
+
+        SettlementData memory settlement = SettlementData({
+            intent: intent,
+            poolKey: poolKey,
+            swapParams: swapParams,
+            quotedAmountOut: quotedAmountOut,
+            solver: msg.sender
+        });
+
+        poolManager.unlock(abi.encode(settlement));
+
+        emit IntentSettled(intent.id, msg.sender);
+    }
+
+    function unlockCallback(bytes calldata data) external override returns (bytes memory) {
+        if (msg.sender != address(poolManager)) revert UnauthorizedPoolManager(msg.sender);
+
+        SettlementData memory settlement = abi.decode(data, (SettlementData));
+
+        bytes memory hookData = abi.encode(settlement.intent.id, settlement.quotedAmountOut);
+        BalanceDelta delta = poolManager.swap(settlement.poolKey, settlement.swapParams, hookData);
+
+        _settleDeltas(settlement.intent.user, settlement.poolKey, delta);
+
+        return bytes("");
+    }
+
+    function _settleDeltas(address payer, PoolKey memory poolKey, BalanceDelta delta) internal {
+        int128 amount0 = delta.amount0();
+        int128 amount1 = delta.amount1();
+
+        if (amount0 > 0) {
+            poolKey.currency0.settle(poolManager, payer, uint256(uint128(amount0)), false);
+        } else if (amount0 < 0) {
+            poolKey.currency0.take(poolManager, payer, uint256(uint128(-amount0)), false);
+        }
+
+        if (amount1 > 0) {
+            poolKey.currency1.settle(poolManager, payer, uint256(uint128(amount1)), false);
+        } else if (amount1 < 0) {
+            poolKey.currency1.take(poolManager, payer, uint256(uint128(-amount1)), false);
+        }
+    }
+}

--- a/contracts/test/JACKSettlementAdapter.t.sol
+++ b/contracts/test/JACKSettlementAdapter.t.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {JACKSettlementAdapter} from "../src/JACKSettlementAdapter.sol";
+import {JACKPolicyHook} from "../src/JACKPolicyHook.sol";
+import {IPoolManager} from "v4-core/interfaces/IPoolManager.sol";
+import {Hooks} from "v4-core/libraries/Hooks.sol";
+import {BalanceDelta} from "v4-core/types/BalanceDelta.sol";
+import {Currency} from "v4-core/types/Currency.sol";
+import {PoolKey} from "v4-core/types/PoolKey.sol";
+import {SwapParams} from "v4-core/types/PoolOperation.sol";
+
+contract MockPoolManager {
+    BalanceDelta public swapDelta;
+    bytes public lastHookData;
+    bool public reentrancyBlocked;
+    bool public attemptReenter;
+    address public adapter;
+    bytes public reenterPayload;
+
+    function setSwapDelta(BalanceDelta delta) external {
+        swapDelta = delta;
+    }
+
+    function setReenter(address _adapter, bytes calldata payload) external {
+        adapter = _adapter;
+        reenterPayload = payload;
+        attemptReenter = true;
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        if (attemptReenter) {
+            attemptReenter = false;
+            (JACKSettlementAdapter.Intent memory intent, PoolKey memory poolKey, SwapParams memory swapParams, uint256 quotedAmountOut) =
+                abi.decode(reenterPayload, (JACKSettlementAdapter.Intent, PoolKey, SwapParams, uint256));
+            try JACKSettlementAdapter(adapter).settleIntent(intent, poolKey, swapParams, quotedAmountOut) {
+                reentrancyBlocked = false;
+            } catch {
+                reentrancyBlocked = true;
+            }
+        }
+
+        return JACKSettlementAdapter(msg.sender).unlockCallback(data);
+    }
+
+    function swap(PoolKey calldata, SwapParams calldata, bytes calldata hookData) external returns (BalanceDelta) {
+        lastHookData = hookData;
+        return swapDelta;
+    }
+
+    function take(Currency, address, uint256, bool) external {}
+
+    function settle(Currency, address, uint256, bool) external returns (uint256) {
+        return 0;
+    }
+}
+
+contract JACKSettlementAdapterTest is Test {
+    uint160 internal constant CLEAR_ALL_HOOK_FLAGS_MASK = ~uint160((1 << 14) - 1);
+
+    JACKSettlementAdapter internal adapter;
+    JACKPolicyHook internal hook;
+    MockPoolManager internal poolManager;
+
+    address internal solver = address(0xBEEF);
+    address internal user;
+    uint256 internal userKey;
+
+    bytes32 internal intentId = keccak256("intent-1");
+
+    event IntentSettled(bytes32 indexed intentId, address indexed solver);
+
+    function setUp() public {
+        poolManager = new MockPoolManager();
+
+        address hookAddress =
+            address(uint160(type(uint160).max & CLEAR_ALL_HOOK_FLAGS_MASK | Hooks.BEFORE_SWAP_FLAG));
+        deployCodeTo("JACKPolicyHook.sol:JACKPolicyHook", abi.encode(IPoolManager(address(poolManager))), hookAddress);
+        hook = JACKPolicyHook(hookAddress);
+
+        adapter = new JACKSettlementAdapter(address(hook));
+        adapter.setAuthorizedSolver(solver, true);
+
+        userKey = 0xA11CE;
+        user = vm.addr(userKey);
+    }
+
+    function _buildIntent(uint256 deadline) internal view returns (JACKSettlementAdapter.Intent memory) {
+        return JACKSettlementAdapter.Intent({
+            id: intentId,
+            user: user,
+            tokenIn: address(0x1),
+            tokenOut: address(0x2),
+            amountIn: 100,
+            minAmountOut: 90,
+            deadline: deadline,
+            signature: ""
+        });
+    }
+
+    function _signIntent(JACKSettlementAdapter.Intent memory intent) internal view returns (bytes memory) {
+        bytes32 digest = adapter.hashIntent(intent);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _defaultSwapParams() internal pure returns (PoolKey memory, SwapParams memory) {
+        PoolKey memory key;
+        SwapParams memory params = SwapParams({zeroForOne: true, amountSpecified: -int256(100), sqrtPriceLimitX96: 0});
+        return (key, params);
+    }
+
+    function testValidSettlementEmitsEventAndUsesHookData() public {
+        uint256 deadline = block.timestamp + 1 days;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = _signIntent(intent);
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut, intent.minAmountOut, 0, deadline, address(this));
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+        uint256 quotedAmountOut = intent.minAmountOut;
+
+        vm.expectEmit(true, true, false, true, address(adapter));
+        emit IntentSettled(intent.id, solver);
+
+        vm.prank(solver);
+        adapter.settleIntent(intent, key, params, quotedAmountOut);
+
+        assertEq(poolManager.lastHookData(), abi.encode(intent.id, quotedAmountOut));
+    }
+
+    function testRejectsInvalidSignature() public {
+        uint256 deadline = block.timestamp + 1 days;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = "bad";
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut, intent.minAmountOut, 0, deadline, address(this));
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+
+        vm.prank(solver);
+        vm.expectRevert(JACKSettlementAdapter.InvalidSignature.selector);
+        adapter.settleIntent(intent, key, params, intent.minAmountOut);
+    }
+
+    function testRejectsUnauthorizedSolver() public {
+        uint256 deadline = block.timestamp + 1 days;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = _signIntent(intent);
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut, intent.minAmountOut, 0, deadline, address(this));
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+
+        vm.prank(address(0xCAFE));
+        vm.expectRevert(abi.encodeWithSelector(JACKSettlementAdapter.UnauthorizedSolver.selector, address(0xCAFE)));
+        adapter.settleIntent(intent, key, params, intent.minAmountOut);
+    }
+
+    function testPolicyRejectionBubblesUp() public {
+        uint256 deadline = block.timestamp + 1 days;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = _signIntent(intent);
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut + 10, intent.minAmountOut + 10, 0, deadline, address(this));
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(JACKSettlementAdapter.PolicyRejected.selector, intent.id, hook.REASON_SLIPPAGE_EXCEEDED())
+        );
+        adapter.settleIntent(intent, key, params, intent.minAmountOut);
+    }
+
+    function testPolicyExpirationReverts() public {
+        uint256 deadline = block.timestamp + 1;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = _signIntent(intent);
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut, intent.minAmountOut, 0, deadline, address(this));
+        vm.warp(deadline + 1);
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(JACKSettlementAdapter.PolicyRejected.selector, intent.id, hook.REASON_POLICY_EXPIRED())
+        );
+        adapter.settleIntent(intent, key, params, intent.minAmountOut);
+    }
+
+    function testReentrancyGuardBlocksNestedSettle() public {
+        uint256 deadline = block.timestamp + 1 days;
+        JACKSettlementAdapter.Intent memory intent = _buildIntent(deadline);
+        intent.signature = _signIntent(intent);
+
+        hook.setPolicyWithSlippage(intent.id, intent.minAmountOut, intent.minAmountOut, 0, deadline, address(this));
+
+        (PoolKey memory key, SwapParams memory params) = _defaultSwapParams();
+        uint256 quotedAmountOut = intent.minAmountOut;
+
+        poolManager.setReenter(address(adapter), abi.encode(intent, key, params, quotedAmountOut));
+
+        vm.prank(solver);
+        adapter.settleIntent(intent, key, params, quotedAmountOut);
+
+        assertTrue(poolManager.reentrancyBlocked());
+    }
+}


### PR DESCRIPTION
### Motivation

- Make the SettlementAdapter production-ready by replacing the MVP stub with real Uniswap v4 swap execution and policy integration. 
- Enforce solver trust and user intent authenticity via EIP-712 signatures and a solver whitelist to prevent unauthorized settlements. 
- Provide test coverage for settlement behavior, policy rejections, signature validation, solver authorization, and reentrancy protection.

### Description

- Move the adapter implementation into `contracts/src/JACKSettlementAdapter.sol` and add a root-level shim `contracts/JACKSettlementAdapter.sol` to preserve backwards-compatible imports. 
- Implement `JACKSettlementAdapter` with `EIP712`/`SignatureChecker` based intent hashing, `onlySolver` ACL, owner management, and `settleIntent` which calls `poolManager.unlock(...)` and uses `unlockCallback` → `poolManager.swap(...)` with hook data to trigger `JACKPolicyHook` checks and collect a `BalanceDelta`. 
- Settle pool deltas using Uniswap v4 `Currency.settle`/`Currency.take` helpers and emit `IntentSettled` and relevant ownership/authorization events. 
- Add a Forge test suite `contracts/test/JACKSettlementAdapter.t.sol` and a `MockPoolManager` to exercise valid settlement, invalid signature, unauthorized solver, policy slippage/expiration rejections, and reentrancy blocking.

### Testing

- Added `contracts/test/JACKSettlementAdapter.t.sol` which covers: valid settlement + hook data, invalid signature rejection, unauthorized solver rejection, policy rejection bubbling, policy expiration, and reentrancy guard behavior. 
- No automated tests were executed as part of this PR; the new Forge test file is included and ready to run locally or in CI. 
- Existing `JACKPolicyHook` tests remain present in the repo (unchanged by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870ddb7cf8833282ddf71a0ed333e1)