### PR TITLE
Fix ReDoS risks in SDK error parsing

### DIFF
--- a/packages/sdk/src/lifi/utils.ts
+++ b/packages/sdk/src/lifi/utils.ts
@@ -36,6 +36,14 @@ export function fromBaseUnits(amount: string, decimals: number): string {
   if (!amount || amount === '0') return '0';
   const padded = amount.padStart(decimals + 1, '0');
   const whole = padded.slice(0, -decimals) || '0';
-  const fraction = padded.slice(-decimals).replace(/0+$/, '');
+  const fraction = trimTrailingZeros(padded.slice(-decimals));
   return fraction ? `${whole}.${fraction}` : whole;
+}
+
+function trimTrailingZeros(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === '0') {
+    end -= 1;
+  }
+  return value.slice(0, end);
 }


### PR DESCRIPTION
### Motivation
- Address CodeQL/scan findings about polynomial regular-expression ReDoS risks in SDK parsing and formatting logic by removing regexes that operate on uncontrolled input.
- Ensure revert reason extraction and base-unit formatting are robust against pathological or large inputs.

### Description
- Replace regex-based revert reason parsing in `packages/sdk/src/yellow/yellow-provider.ts` with index-based parsing and small helper functions `extractRevertReasonFromSuffix` and `findFirstLineBreak` to safely extract reasons from messages.
- Replace trailing-zero stripping via `replace(/0+$/, '')` in `packages/sdk/src/lifi/utils.ts` with an explicit loop helper `trimTrailingZeros` to avoid regex-driven worst-case behavior.
- Keep public behavior intact: `extractRevertReason` still returns the same reason strings for common formats, and `fromBaseUnits` output is unchanged for normal inputs.

### Testing
- Pre-commit hooks and linters ran as part of the commit workflow and completed successfully (including `secretlint` and the repo doc-clean task). 
- No unit tests or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69880cfef8cc8332865adc8fa65a720d)